### PR TITLE
Make NFC fast again

### DIFF
--- a/lib/Adafruit PN532/Adafruit_PN532.cpp
+++ b/lib/Adafruit PN532/Adafruit_PN532.cpp
@@ -1579,7 +1579,6 @@ void Adafruit_PN532::readdata(uint8_t *buff, uint8_t n) {
     // Discard the leading 0x01
     i2c_recv();
     for (uint8_t i = 0; i < n; i++) {
-      delay(1);
       buff[i] = i2c_recv();
 #ifdef PN532DEBUG
       PN532DEBUGPRINT.print(F(" 0x"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,7 @@ void Start125KHz() {
 void StartNFC() {
   xTaskCreatePinnedToCore(MainNFCTask, 
       "nfc_task", 10000, nullptr,      
-      1, &_125khz_task, 0);        
+      5, &_125khz_task, 0);        
 }
 
 const uint32_t kStartupBeeps[] = {200, 100, 200};


### PR DESCRIPTION
- deleted delay while reading from i2c in PN532 lib
- increased NFCtask priotity to 5